### PR TITLE
Use new url for internal devpi server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
     environment{
         SLACK_CHANNEL = '#platform-engineering-ci'
-        PRIVATE_PYPI = "https://mirror-sac0-0000.backblaze.com/pypi/bz/uploads"
+        PRIVATE_PYPI = "https://devpi-sac0.backblaze.com/bz/uploads"
 
     }
 


### PR DESCRIPTION
@SesquipedalianDefenestrator This is why the build for your license change failed. 

This happened when we moved the mirror servers to nginx a while back and it wasn't worth trying to maintain the sub-path setup in favor of just having domain names.